### PR TITLE
Apunto a la versión https de los logos en el checkout

### DIFF
--- a/view/frontend/web/template/payment/tphibrido.html
+++ b/view/frontend/web/template/payment/tphibrido.html
@@ -1,6 +1,6 @@
 <!--
 /**
- * Copyright © 2015 Magento. All rights reserved.
+ * Copyright ï¿½ 2015 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 -->
@@ -18,7 +18,7 @@
         <label data-bind="attr: {'for': getCode()}" class="label"><span data-bind="text: getTitle()"></span></label>
     </div>
     <div class="payment-method-content">
-		<img src="http://www.todopago.com.ar/sites/todopago.com.ar/files/pluginstarjeta.jpg" title="TodoPago tarjetas" alt="TodoPago tarjetas" />
+		<img src="https://www.todopago.com.ar/sites/todopago.com.ar/files/pluginstarjeta.jpg" title="TodoPago tarjetas" alt="TodoPago tarjetas" />
         <!-- ko foreach: getRegion('messages') -->
 			<!-- ko template: getTemplate() --><!-- /ko -->
         <!--/ko-->

--- a/view/frontend/web/template/payment/tpredirect.html
+++ b/view/frontend/web/template/payment/tpredirect.html
@@ -13,7 +13,7 @@
         <label data-bind="attr: {'for': getCode()}" class="label"><span data-bind="text: getTitle()"></span></label>
     </div>
     <div class="payment-method-content">
-		<img src="http://www.todopago.com.ar/sites/todopago.com.ar/files/pluginstarjeta.jpg" title="TodoPago tarjetas" alt="TodoPago tarjetas" />
+		<img src="https://www.todopago.com.ar/sites/todopago.com.ar/files/pluginstarjeta.jpg" title="TodoPago tarjetas" alt="TodoPago tarjetas" />
         <!-- ko foreach: getRegion('messages') -->
 			<!-- ko template: getTemplate() --><!-- /ko -->
         <!--/ko-->


### PR DESCRIPTION
Con la versión actual, en el checkout se "rompe" el https porque la imágen en cuestión es no segura